### PR TITLE
Feature Enhancement: Conditional Rarity Tags

### DIFF
--- a/src/RarityTiedSpawner.cs
+++ b/src/RarityTiedSpawner.cs
@@ -19,8 +19,10 @@ namespace RarityTiedSpawner {
                     string jdata = reader.ReadToEnd();
                     settings = JsonConvert.DeserializeObject<Settings>(jdata);
                 }
-                modLog = new DeferringLogger(modDirectory, "RarityTiedSpawner", "RTS", settings.debug, settings.trace);
+                modLog = new DeferringLogger(modDirectory, "RarityTiedSpawner", "RTS", settings.Debug, settings.Trace);
                 modLog.Debug?.Write($"Loaded settings from {modDir}/settings.json. Version {typeof(Settings).Assembly.GetName().Version}");
+                modLog.Debug?.Write($"ExcludeTag: {settings.ExcludeTag}");
+                modLog.Debug?.Write($"DynamicTag: {settings.DynamicTag}");
             } catch (Exception e) {
                 settings = new Settings();
                 modLog = new DeferringLogger(modDir, "RarityTiedSpawner", "RTS", true, true);

--- a/src/RarityTiedSpawner.cs
+++ b/src/RarityTiedSpawner.cs
@@ -1,16 +1,11 @@
-using System;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Collections.Generic;
-using Newtonsoft.Json;
 using Harmony;
 using IRBTModUtils.Logging;
-using BattleTech;
-using UnityEngine;
+using Newtonsoft.Json;
+using System;
+using System.IO;
+using System.Reflection;
 
-namespace RarityTiedSpawner
-{
+namespace RarityTiedSpawner {
     public class RTS {
         internal static DeferringLogger modLog;
         internal static string modDir;
@@ -26,9 +21,7 @@ namespace RarityTiedSpawner
                 }
                 modLog = new DeferringLogger(modDirectory, "RarityTiedSpawner", "RTS", settings.debug, settings.trace);
                 modLog.Debug?.Write($"Loaded settings from {modDir}/settings.json. Version {typeof(Settings).Assembly.GetName().Version}");
-            }
-
-            catch (Exception e) {
+            } catch (Exception e) {
                 settings = new Settings();
                 modLog = new DeferringLogger(modDir, "RarityTiedSpawner", "RTS", true, true);
                 modLog.Error?.Write(e);

--- a/src/RarityTiedSpawner.cs
+++ b/src/RarityTiedSpawner.cs
@@ -21,8 +21,6 @@ namespace RarityTiedSpawner {
                 }
                 modLog = new DeferringLogger(modDirectory, "RarityTiedSpawner", "RTS", settings.debug, settings.trace);
                 modLog.Debug?.Write($"Loaded settings from {modDir}/settings.json. Version {typeof(Settings).Assembly.GetName().Version}");
-                modLog.Debug?.Write($"ExcludeTag: {settings.excludeTag}");
-                modLog.Debug?.Write($"DynamicTag: {settings.dynamicTag}");
             } catch (Exception e) {
                 settings = new Settings();
                 modLog = new DeferringLogger(modDir, "RarityTiedSpawner", "RTS", true, true);

--- a/src/RarityTiedSpawner.cs
+++ b/src/RarityTiedSpawner.cs
@@ -19,10 +19,10 @@ namespace RarityTiedSpawner {
                     string jdata = reader.ReadToEnd();
                     settings = JsonConvert.DeserializeObject<Settings>(jdata);
                 }
-                modLog = new DeferringLogger(modDirectory, "RarityTiedSpawner", "RTS", settings.Debug, settings.Trace);
+                modLog = new DeferringLogger(modDirectory, "RarityTiedSpawner", "RTS", settings.debug, settings.trace);
                 modLog.Debug?.Write($"Loaded settings from {modDir}/settings.json. Version {typeof(Settings).Assembly.GetName().Version}");
-                modLog.Debug?.Write($"ExcludeTag: {settings.ExcludeTag}");
-                modLog.Debug?.Write($"DynamicTag: {settings.DynamicTag}");
+                modLog.Debug?.Write($"ExcludeTag: {settings.excludeTag}");
+                modLog.Debug?.Write($"DynamicTag: {settings.dynamicTag}");
             } catch (Exception e) {
                 settings = new Settings();
                 modLog = new DeferringLogger(modDir, "RarityTiedSpawner", "RTS", true, true);

--- a/src/data/Settings.cs
+++ b/src/data/Settings.cs
@@ -2,10 +2,10 @@ using System.Collections.Generic;
 
 namespace RarityTiedSpawner {
     public class Settings {
-        public bool Debug = false;
-        public bool Trace = false;
-        public string ExcludeTag = "";
-        public string DynamicTag = "";
-        public Dictionary<string, int> MoreCommonTags = new Dictionary<string, int>();
+        public bool debug = false;
+        public bool trace = false;
+        public string excludeTag = "";
+        public string dynamicTag = "";
+        public Dictionary<string, int> moreCommonTags = new Dictionary<string, int>();
     }
 }

--- a/src/data/Settings.cs
+++ b/src/data/Settings.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace RarityTiedSpawner {
     public class Settings {

--- a/src/data/Settings.cs
+++ b/src/data/Settings.cs
@@ -2,8 +2,10 @@ using System.Collections.Generic;
 
 namespace RarityTiedSpawner {
     public class Settings {
-        public bool debug = false;
-        public bool trace = false;
-        public Dictionary<string, int> moreCommonTags = new Dictionary<string, int>();
+        public bool Debug = false;
+        public bool Trace = false;
+        public string ExcludeTag = "";
+        public string DynamicTag = "";
+        public Dictionary<string, int> MoreCommonTags = new Dictionary<string, int>();
     }
 }

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -1,7 +1,9 @@
 {
-  "debug": true,
-  "trace": true,
-  "moreCommonTags": {
+  "Debug": true,
+  "Trace": true,
+  "ExcludeTag": "not",
+  "DynamicTag": "unit_rarity",
+  "MoreCommonTags": {
     "unit_mech": 1
   }
 }

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -1,9 +1,9 @@
 {
-  "Debug": true,
-  "Trace": true,
-  "ExcludeTag": "not",
-  "DynamicTag": "unit_rarity",
-  "MoreCommonTags": {
+  "debug": true,
+  "trace": true,
+  "excludeTag": "not",
+  "dynamicTag": "unit_rarity",
+  "moreCommonTags": {
     "unit_mech": 1
   }
 }

--- a/src/patches/TagSetQueryExtensions.cs
+++ b/src/patches/TagSetQueryExtensions.cs
@@ -122,10 +122,10 @@ namespace RarityTiedSpawner {
             private Dictionary<string, List<Tag_MDD>> MechTagCache;
 
             private static Regex EndNumberPattern = new Regex(@"-?\d+$", RegexOptions.Compiled);
-            private static Regex NegativePattern = new Regex($"^{RTS.settings.ExcludeTag}_.+{RTS.settings.DynamicTag}_-?\\d+$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-            private static Regex PositiveTagPattern = new Regex($"^.+_{RTS.settings.DynamicTag}_-?\\d+$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-            private static Regex TagPattern = new Regex($"^{RTS.settings.DynamicTag}_-?\\d+$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-            private static Regex DynamicTagPattern = new Regex($"{RTS.settings.DynamicTag}_-?\\d+$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            private static Regex NegativePattern = new Regex($"^{RTS.settings.excludeTag}_.+{RTS.settings.dynamicTag}_-?\\d+$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            private static Regex PositiveTagPattern = new Regex($"^.+_{RTS.settings.dynamicTag}_-?\\d+$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            private static Regex TagPattern = new Regex($"^{RTS.settings.dynamicTag}_-?\\d+$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            private static Regex DynamicTagPattern = new Regex($"{RTS.settings.dynamicTag}_-?\\d+$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
             public long timeUsed = 0;
 
@@ -141,7 +141,7 @@ namespace RarityTiedSpawner {
 
             private TagCache() {
                 NonTagCachhe = new HashSet<string>();
-                MoreCommonTags = RTS.settings.MoreCommonTags;
+                MoreCommonTags = RTS.settings.moreCommonTags;
                 GenericTags = new Dictionary<string, Regex>();
                 NumberStrings = new Dictionary<string, int> {
                     { "0", 0 },
@@ -171,11 +171,7 @@ namespace RarityTiedSpawner {
                 MechTagCache = new Dictionary<string, List<Tag_MDD>>();
             }
 
-            public int GetNumberToAdd(UnitDef_MDD unitDef, TagSet requiredTags, TagSet excludedTags, bool logTime = false) {
-                var stopwatch = new Stopwatch();
-                if (logTime) {
-                    stopwatch.Start();
-                }
+            public int GetNumberToAdd(UnitDef_MDD unitDef, TagSet requiredTags, TagSet excludedTags) {
                 int toAdd = 0;
 
                 if (!MechTagCache.ContainsKey(unitDef.UnitDefID)) {
@@ -266,10 +262,6 @@ namespace RarityTiedSpawner {
                         continue;
                     }
                 }
-                if (logTime) { 
-                    stopwatch.Stop();
-                    timeUsed += stopwatch.ElapsedMilliseconds;
-                }
                 return toAdd;
             }
         }
@@ -286,8 +278,8 @@ namespace RarityTiedSpawner {
                 int toAdd = 0;
 
                 foreach (Tag_MDD tag in unitDef.TagSetEntry.Tags) {
-                    if (s.MoreCommonTags.ContainsKey(tag.Name)) {
-                        toAdd += s.MoreCommonTags[tag.Name];
+                    if (s.moreCommonTags.ContainsKey(tag.Name)) {
+                        toAdd += s.moreCommonTags[tag.Name];
                     }
                 }
                 numberToAddCache[unitDef.UnitDefID] = toAdd;
@@ -299,7 +291,7 @@ namespace RarityTiedSpawner {
                     TagBreakdown.Instance = new TagBreakdown(__result.Count, requiredTags, excludedTags, companyTags);
                     foreach (UnitDef_MDD unitDef in __result.ToArray()) {
                         //int toAdd = numberToAdd(unitDef);
-                        int toAdd = TagCache.Instance.GetNumberToAdd(unitDef, requiredTags, excludedTags, true);
+                        int toAdd = TagCache.Instance.GetNumberToAdd(unitDef, requiredTags, excludedTags);
                         TagBreakdown.Instance.AddUnit(unitDef);
                         if (toAdd > 0) {
                             for (int i = 0; i < toAdd; i++) {

--- a/src/patches/TagSetQueryExtensions.cs
+++ b/src/patches/TagSetQueryExtensions.cs
@@ -3,10 +3,13 @@ using BattleTech.Framework;
 using Harmony;
 using HBS.Collections;
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace RarityTiedSpawner {
     public static class RarityModifications {
@@ -48,9 +51,9 @@ namespace RarityTiedSpawner {
                     Units.Add(unitDef.FriendlyName, new Dictionary<string, int>());
                 }
                 if (!Units[unitDef.FriendlyName].ContainsKey(unitDef.UnitDefID)) {
-                    Units[unitDef.FriendlyName].Add(unitDef.UnitDefID, TagSetQueryExtensions_GetMatchingUnitDefs.numberToAdd(unitDef) + 1);
+                    Units[unitDef.FriendlyName].Add(unitDef.UnitDefID, Math.Max(0, TagCache.Instance.GetNumberToAdd(unitDef, RequiredTags, ExcludedTags)) + 1);
                 } else {
-                    Units[unitDef.FriendlyName][unitDef.UnitDefID] = TagSetQueryExtensions_GetMatchingUnitDefs.numberToAdd(unitDef) + 1;
+                    Units[unitDef.FriendlyName][unitDef.UnitDefID] = Math.Max(0, TagCache.Instance.GetNumberToAdd(unitDef, RequiredTags, ExcludedTags)) + 1;
                 }
             }
 
@@ -89,7 +92,7 @@ namespace RarityTiedSpawner {
                     sortedVariants.AddRange(sortedList[i].Value.AsEnumerable());
                     foreach (var variant in sortedVariants.OrderByDescending(unit => unit.Value)) {
                         builder.AppendLine();
-                        builder.AppendFormat("\t{0,6} | {1,2} - {2}",((double)variant.Value / (double)TotalUnits).ToString("p2", numberInfo), variant.Value, variant.Key);
+                        builder.AppendFormat("\t{0,6} | {1,2} - {2}", ((double)variant.Value / (double)TotalUnits).ToString("p2", numberInfo), variant.Value, variant.Key);
                     }
                     builder.AppendLine();
                 }
@@ -109,10 +112,172 @@ namespace RarityTiedSpawner {
             }
         }
 
+        private class TagCache {
+            private HashSet<string> NonTagCachhe;
+            private Dictionary<string, int> MoreCommonTags;
+            private Dictionary<string, Regex> GenericTags;
+            private Dictionary<string, int> NumberStrings;
+            private Dictionary<string, int> NegativeTags;
+            private Dictionary<string, int> PositiveTags;
+            private Dictionary<string, List<Tag_MDD>> MechTagCache;
+
+            private static Regex EndNumberPattern = new Regex(@"-?\d+$", RegexOptions.Compiled);
+            private static Regex NegativePattern = new Regex($"^{RTS.settings.ExcludeTag}_.+{RTS.settings.DynamicTag}_-?\\d+$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            private static Regex PositiveTagPattern = new Regex($"^.+_{RTS.settings.DynamicTag}_-?\\d+$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            private static Regex TagPattern = new Regex($"^{RTS.settings.DynamicTag}_-?\\d+$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            private static Regex DynamicTagPattern = new Regex($"{RTS.settings.DynamicTag}_-?\\d+$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+            public long timeUsed = 0;
+
+            private static TagCache _instance;
+            public static TagCache Instance {
+                get {
+                    if (_instance == null) {
+                        _instance = new TagCache();
+                    }
+                    return _instance;
+                }
+            }
+
+            private TagCache() {
+                NonTagCachhe = new HashSet<string>();
+                MoreCommonTags = RTS.settings.MoreCommonTags;
+                GenericTags = new Dictionary<string, Regex>();
+                NumberStrings = new Dictionary<string, int> {
+                    { "0", 0 },
+                    { "1", 1 },
+                    { "2", 2 },
+                    { "3", 3 },
+                    { "4", 4 },
+                    { "5", 5 },
+                    { "6", 6 },
+                    { "7", 7 },
+                    { "8", 8 },
+                    { "9", 9 },
+                    { "10", 10 },
+                    { "11", 11 },
+                    { "12", 12 },
+                    { "13", 13 },
+                    { "14", 14 },
+                    { "15", 15 },
+                    { "16", 16 },
+                    { "17", 17 },
+                    { "18", 18 },
+                    { "19", 19 },
+                    { "20", 20 },
+                };
+                PositiveTags = new Dictionary<string,int>();
+                NegativeTags = new Dictionary<string, int>();
+                MechTagCache = new Dictionary<string, List<Tag_MDD>>();
+            }
+
+            public int GetNumberToAdd(UnitDef_MDD unitDef, TagSet requiredTags, TagSet excludedTags, bool logTime = false) {
+                var stopwatch = new Stopwatch();
+                if (logTime) {
+                    stopwatch.Start();
+                }
+                int toAdd = 0;
+
+                if (!MechTagCache.ContainsKey(unitDef.UnitDefID)) {
+                    MechTagCache.Add(unitDef.UnitDefID, unitDef.TagSetEntry.Tags);
+                }
+                foreach (Tag_MDD tag in MechTagCache[unitDef.UnitDefID]) {
+                    if (MoreCommonTags.ContainsKey(tag.Name)) {
+                        toAdd += MoreCommonTags[tag.Name];
+                        continue;
+                    }
+                    if (TagPattern.IsMatch(tag.Name)) {
+                        var numString = EndNumberPattern.Match(tag.Name).Value;
+                        var num = 0;
+                        if (NumberStrings.ContainsKey(numString)) {
+                            num = NumberStrings[numString];
+                        } else {
+                            num = int.Parse(numString);
+                            NumberStrings.Add(numString, num);
+                        }
+                        MoreCommonTags.Add(tag.Name, num);
+                        toAdd += MoreCommonTags[tag.Name];
+                        continue;
+                    }
+                    if (!DynamicTagPattern.IsMatch(tag.Name)) {
+                        MoreCommonTags.Add(tag.Name, 0);
+                        continue;
+                    }
+                    var negativeAdd = 0;
+                    foreach (var negativeTag in excludedTags) {
+                        if (!NegativePattern.IsMatch(tag.Name)) {
+                            break;
+                        }
+                        if (!GenericTags.ContainsKey(negativeTag)) {
+                            GenericTags.Add(negativeTag, new Regex(Regex.Escape(negativeTag), RegexOptions.Compiled | RegexOptions.IgnoreCase));
+                        }
+                        if (!GenericTags[negativeTag].IsMatch(tag.Name)) {
+                            continue;
+                        }
+                        if (NegativeTags.ContainsKey(tag.Name)) {
+                            negativeAdd = NegativeTags[tag.Name];
+                            break;
+                        } else {
+                            var numString = EndNumberPattern.Match(tag.Name).Value;
+                            var num = 0;
+                            if (NumberStrings.ContainsKey(numString)) {
+                                num = NumberStrings[numString];
+                            } else {
+                                num = int.Parse(numString);
+                            }
+                            NegativeTags.Add(tag.Name, num);
+                            negativeAdd = NegativeTags[tag.Name];
+                            break;
+                        }
+                    }
+                    if (negativeAdd > 0) {
+                        toAdd += negativeAdd;
+                        continue;
+                    }
+                    var positiveAdd = 0;
+                    foreach (var positiveTag in requiredTags) {
+                        if (!PositiveTagPattern.IsMatch(tag.Name)) {
+                            break;
+                        }
+                        if (!GenericTags.ContainsKey(positiveTag)) {
+                            GenericTags.Add(positiveTag, new Regex(Regex.Escape(positiveTag), RegexOptions.Compiled | RegexOptions.IgnoreCase));
+                        }
+                        if (!GenericTags[positiveTag].IsMatch(tag.Name)) {
+                            continue;
+                        }
+                        if (PositiveTags.ContainsKey(tag.Name)) {
+                            positiveAdd = PositiveTags[tag.Name];
+                            break;
+                        } else {
+                            var numString = EndNumberPattern.Match(tag.Name).Value;
+                            var num = 0;
+                            if (NumberStrings.ContainsKey(numString)) {
+                                num = NumberStrings[numString];
+                            } else {
+                                num = int.Parse(numString);
+                            }
+                            PositiveTags.Add(tag.Name, num);
+                            positiveAdd = PositiveTags[tag.Name];
+                            break;
+                        }
+                    }
+                    if (positiveAdd > 0) {
+                        toAdd += positiveAdd;
+                        continue;
+                    }
+                }
+                if (logTime) { 
+                    stopwatch.Stop();
+                    timeUsed += stopwatch.ElapsedMilliseconds;
+                }
+                return toAdd;
+            }
+        }
+
         [HarmonyPatch(typeof(TagSetQueryExtensions), "GetMatchingUnitDefs")]
         public static class TagSetQueryExtensions_GetMatchingUnitDefs {
             private static Dictionary<string, int> numberToAddCache = new Dictionary<string, int>();
-            public  static int numberToAdd(UnitDef_MDD unitDef) {
+            public static int numberTsoAdd(UnitDef_MDD unitDef) {
                 if (numberToAddCache.ContainsKey(unitDef.UnitDefID)) {
                     return numberToAddCache[unitDef.UnitDefID];
                 }
@@ -121,8 +286,8 @@ namespace RarityTiedSpawner {
                 int toAdd = 0;
 
                 foreach (Tag_MDD tag in unitDef.TagSetEntry.Tags) {
-                    if (s.moreCommonTags.ContainsKey(tag.Name)) {
-                        toAdd += s.moreCommonTags[tag.Name];
+                    if (s.MoreCommonTags.ContainsKey(tag.Name)) {
+                        toAdd += s.MoreCommonTags[tag.Name];
                     }
                 }
                 numberToAddCache[unitDef.UnitDefID] = toAdd;
@@ -133,7 +298,8 @@ namespace RarityTiedSpawner {
                 try {
                     TagBreakdown.Instance = new TagBreakdown(__result.Count, requiredTags, excludedTags, companyTags);
                     foreach (UnitDef_MDD unitDef in __result.ToArray()) {
-                        int toAdd = numberToAdd(unitDef);
+                        //int toAdd = numberToAdd(unitDef);
+                        int toAdd = TagCache.Instance.GetNumberToAdd(unitDef, requiredTags, excludedTags, true);
                         TagBreakdown.Instance.AddUnit(unitDef);
                         if (toAdd > 0) {
                             for (int i = 0; i < toAdd; i++) {
@@ -158,6 +324,7 @@ namespace RarityTiedSpawner {
                     }
                     TagBreakdown.Instance.Selected = __result;
                     RTS.modLog.Info?.Write($"Generating new Spawn Table\n{TagBreakdown.Instance.CreateOutputTable()}");
+                    RTS.modLog.Info?.Write($"Tag Processing Time Total: {TagCache.Instance.timeUsed}ms");
 
                 } catch (Exception e) {
                     RTS.modLog.Error?.Write(e);

--- a/src/patches/TagSetQueryExtensions.cs
+++ b/src/patches/TagSetQueryExtensions.cs
@@ -167,7 +167,6 @@ namespace RarityTiedSpawner {
                 try {
                     RTS.modLog.Info?.Write($"Old Length: {__result.Count}");
                     foreach (UnitDef_MDD unitDef in __result.ToArray()) {
-                        //int toAdd = numberToAdd(unitDef);
                         int toAdd = TagCache.Instance.GetNumberToAdd(unitDef, requiredTags, excludedTags);
                         if (toAdd > 0) {
                             RTS.modLog.Info?.Write($"Possible unit: {unitDef.UnitDefID}. Adding {toAdd} to list.");

--- a/src/patches/TagSetQueryExtensions.cs
+++ b/src/patches/TagSetQueryExtensions.cs
@@ -13,105 +13,6 @@ using System.Text.RegularExpressions;
 
 namespace RarityTiedSpawner {
     public static class RarityModifications {
-        private class TagBreakdown {
-            public Dictionary<string, Dictionary<string, int>> Units = new Dictionary<string, Dictionary<string, int>>();
-            private int _totalUnits = 0;
-            public readonly int OldLength;
-            public readonly TagSet RequiredTags;
-            public readonly TagSet ExcludedTags;
-            public readonly TagSet CompanyTags;
-            public UnitDef_MDD Selected { get; set; }
-
-            public static TagBreakdown Instance;
-
-            private readonly static NumberFormatInfo numberInfo = new NumberFormatInfo() {
-                PercentPositivePattern = 1
-            };
-            public int TotalUnits {
-                get {
-                    if (_totalUnits != 0) {
-                        return _totalUnits;
-                    }
-                    foreach (var unit in Units) {
-                        _totalUnits += GetUnitCount(unit.Key);
-                    }
-                    return _totalUnits;
-                }
-            }
-
-            public TagBreakdown(int oldLength, TagSet requiredTags, TagSet excludedTags, TagSet companyTags) {
-                this.OldLength = oldLength;
-                this.RequiredTags = requiredTags;
-                this.ExcludedTags = excludedTags;
-                this.CompanyTags = companyTags;
-            }
-
-            public void AddUnit(UnitDef_MDD unitDef) {
-                if (!Units.ContainsKey(unitDef.FriendlyName)) {
-                    Units.Add(unitDef.FriendlyName, new Dictionary<string, int>());
-                }
-                if (!Units[unitDef.FriendlyName].ContainsKey(unitDef.UnitDefID)) {
-                    Units[unitDef.FriendlyName].Add(unitDef.UnitDefID, Math.Max(0, TagCache.Instance.GetNumberToAdd(unitDef, RequiredTags, ExcludedTags)) + 1);
-                } else {
-                    Units[unitDef.FriendlyName][unitDef.UnitDefID] = Math.Max(0, TagCache.Instance.GetNumberToAdd(unitDef, RequiredTags, ExcludedTags)) + 1;
-                }
-            }
-
-            public int GetUnitCount(string FriendlyName) {
-                var result = 0;
-                if (!Units.ContainsKey(FriendlyName)) {
-                    return result;
-                }
-                foreach (var unit in Units[FriendlyName]) {
-                    result += unit.Value;
-                }
-                return result;
-            }
-
-            public string CreateOutputTable() {
-                StringBuilder builder = new StringBuilder();
-                List<KeyValuePair<string, Dictionary<string, int>>> sortedUnits = new();
-                builder.AppendLine();
-                builder.Append("----------------------------------------------------------------------------------------------------");
-                builder.AppendLine();
-                builder.AppendFormat("Old Length: {0} | New Length: {1}", OldLength, TotalUnits);
-                builder.AppendLine();
-                builder.AppendFormat("Required Tags: {0}", string.Join(", ", RequiredTags.items));
-                builder.AppendLine();
-                builder.AppendFormat("Excluded Tags: {0}", string.Join(", ", ExcludedTags.items));
-                builder.AppendLine();
-                builder.Append("----------------------------------------------------------------------------------------------------");
-                builder.AppendLine();
-
-                sortedUnits.AddRange(Units.AsEnumerable());
-                var sortedList = sortedUnits.OrderByDescending(unit => GetUnitCount(unit.Key)).ToList();
-                for (int i = 0; i < sortedList.Count; i++) {
-                    builder.AppendFormat("{0,6} | {1,2} - {2}", ((double)GetUnitCount(sortedList[i].Key) / (double)TotalUnits).ToString("p2", numberInfo), GetUnitCount(sortedList[i].Key), sortedList[i].Key);
-
-                    List<KeyValuePair<string, int>> sortedVariants = new();
-                    sortedVariants.AddRange(sortedList[i].Value.AsEnumerable());
-                    foreach (var variant in sortedVariants.OrderByDescending(unit => unit.Value)) {
-                        builder.AppendLine();
-                        builder.AppendFormat("\t{0,6} | {1,2} - {2}", ((double)variant.Value / (double)TotalUnits).ToString("p2", numberInfo), variant.Value, variant.Key);
-                    }
-                    builder.AppendLine();
-                }
-                builder.Append("----------------------------------------------------------------------------------------------------");
-                builder.AppendLine();
-                builder.AppendFormat("Selected: {0} - {1} | ({2}/{3}) | ({4}/{5})",
-                    Selected.FriendlyName,
-                    Selected.UnitDefID,
-                    ((double)GetUnitCount(Selected.FriendlyName) / (double)TotalUnits).ToString("p2", numberInfo),
-                    ((double)Units[Selected.FriendlyName][Selected.UnitDefID] / (double)TotalUnits).ToString("p2", numberInfo),
-                    GetUnitCount(Selected.FriendlyName),
-                    Units[Selected.FriendlyName][Selected.UnitDefID]);
-                builder.AppendLine();
-                builder.Append("----------------------------------------------------------------------------------------------------");
-                builder.AppendLine();
-                return builder.ToString();
-            }
-        }
-
         private class TagCache {
             private HashSet<string> NonTagCachhe;
             private Dictionary<string, int> MoreCommonTags;
@@ -270,36 +171,18 @@ namespace RarityTiedSpawner {
         public static class TagSetQueryExtensions_GetMatchingUnitDefs {
             private static void Postfix(ref List<UnitDef_MDD> __result, TagSet requiredTags, TagSet excludedTags, TagSet companyTags) {
                 try {
-                    TagBreakdown.Instance = new TagBreakdown(__result.Count, requiredTags, excludedTags, companyTags);
+                    RTS.modLog.Info?.Write($"Old Length: {__result.Count}");
                     foreach (UnitDef_MDD unitDef in __result.ToArray()) {
                         //int toAdd = numberToAdd(unitDef);
                         int toAdd = TagCache.Instance.GetNumberToAdd(unitDef, requiredTags, excludedTags);
-                        TagBreakdown.Instance.AddUnit(unitDef);
                         if (toAdd > 0) {
+                            RTS.modLog.Info?.Write($"Possible unit: {unitDef.UnitDefID}. Adding {toAdd} to list.");
                             for (int i = 0; i < toAdd; i++) {
                                 __result.Add(unitDef);
                             }
                         }
                     }
-
-                } catch (Exception e) {
-                    RTS.modLog.Error?.Write(e);
-                }
-            }
-        }
-
-        [HarmonyPatch(typeof(UnitSpawnPointOverride), nameof(UnitSpawnPointOverride.SelectTaggedUnitDef))]
-        public static class TagSetQueryExtensions_SelectTaggedUnitDef {
-            private static void Postfix(ref UnitDef_MDD __result) {
-                try {
-                    if (TagBreakdown.Instance == null) {
-                        RTS.modLog.Info?.Write("Failed to find TagBreakdown");
-                        return;
-                    }
-                    TagBreakdown.Instance.Selected = __result;
-                    RTS.modLog.Info?.Write($"Generating new Spawn Table\n{TagBreakdown.Instance.CreateOutputTable()}");
-                    RTS.modLog.Info?.Write($"Tag Processing Time Total: {TagCache.Instance.timeUsed}ms");
-
+                    RTS.modLog.Info?.Write($"New Length: {__result.Count}");
                 } catch (Exception e) {
                     RTS.modLog.Error?.Write(e);
                 }

--- a/src/patches/TagSetQueryExtensions.cs
+++ b/src/patches/TagSetQueryExtensions.cs
@@ -1,14 +1,8 @@
 using BattleTech.Data;
-using BattleTech.Framework;
 using Harmony;
 using HBS.Collections;
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace RarityTiedSpawner {

--- a/src/patches/TagSetQueryExtensions.cs
+++ b/src/patches/TagSetQueryExtensions.cs
@@ -1,49 +1,168 @@
+using BattleTech.Data;
+using BattleTech.Framework;
+using Harmony;
+using HBS.Collections;
 using System;
 using System.Collections.Generic;
-using Harmony;
-using Localize;
-using BattleTech;
-using BattleTech.Data;
+using System.Globalization;
+using System.Linq;
+using System.Text;
 
 namespace RarityTiedSpawner {
-    [HarmonyPatch(typeof(TagSetQueryExtensions), "GetMatchingUnitDefs")]
+    public static class RarityModifications {
+        private class TagBreakdown {
+            public Dictionary<string, Dictionary<string, int>> Units = new Dictionary<string, Dictionary<string, int>>();
+            private int _totalUnits = 0;
+            public readonly int OldLength;
+            public readonly TagSet RequiredTags;
+            public readonly TagSet ExcludedTags;
+            public readonly TagSet CompanyTags;
+            public UnitDef_MDD Selected { get; set; }
 
-    public static class TagSetQueryExtensions_GetMatchingUnitDefs {
-        private static Dictionary<string, int> numberToAddCache = new Dictionary<string, int>();
-        private static int numberToAdd(UnitDef_MDD unitDef) {
-            if (numberToAddCache.ContainsKey(unitDef.UnitDefID)) {
-                return numberToAddCache[unitDef.UnitDefID];
-            }
+            public static TagBreakdown Instance;
 
-            Settings s = RTS.settings;
-            int toAdd = 0;
-
-            foreach (Tag_MDD tag in unitDef.TagSetEntry.Tags) {
-                if (s.moreCommonTags.ContainsKey(tag.Name)) {
-                    toAdd += s.moreCommonTags[tag.Name];
+            private readonly static NumberFormatInfo numberInfo = new NumberFormatInfo() {
+                PercentPositivePattern = 1
+            };
+            public int TotalUnits {
+                get {
+                    if (_totalUnits != 0) {
+                        return _totalUnits;
+                    }
+                    foreach (var unit in Units) {
+                        _totalUnits += GetUnitCount(unit.Key);
+                    }
+                    return _totalUnits;
                 }
             }
-            numberToAddCache[unitDef.UnitDefID] = toAdd;
-            return toAdd;
+
+            public TagBreakdown(int oldLength, TagSet requiredTags, TagSet excludedTags, TagSet companyTags) {
+                this.OldLength = oldLength;
+                this.RequiredTags = requiredTags;
+                this.ExcludedTags = excludedTags;
+                this.CompanyTags = companyTags;
+            }
+
+            public void AddUnit(UnitDef_MDD unitDef) {
+                if (!Units.ContainsKey(unitDef.FriendlyName)) {
+                    Units.Add(unitDef.FriendlyName, new Dictionary<string, int>());
+                }
+                if (!Units[unitDef.FriendlyName].ContainsKey(unitDef.UnitDefID)) {
+                    Units[unitDef.FriendlyName].Add(unitDef.UnitDefID, TagSetQueryExtensions_GetMatchingUnitDefs.numberToAdd(unitDef) + 1);
+                } else {
+                    Units[unitDef.FriendlyName][unitDef.UnitDefID] = TagSetQueryExtensions_GetMatchingUnitDefs.numberToAdd(unitDef) + 1;
+                }
+            }
+
+            public int GetUnitCount(string FriendlyName) {
+                var result = 0;
+                if (!Units.ContainsKey(FriendlyName)) {
+                    return result;
+                }
+                foreach (var unit in Units[FriendlyName]) {
+                    result += unit.Value;
+                }
+                return result;
+            }
+
+            public string CreateOutputTable() {
+                StringBuilder builder = new StringBuilder();
+                List<KeyValuePair<string, Dictionary<string, int>>> sortedUnits = new();
+                builder.AppendLine();
+                builder.Append("----------------------------------------------------------------------");
+                builder.AppendLine();
+                builder.AppendFormat("Old Length: {0} | New Length: {1}", OldLength, TotalUnits);
+                builder.AppendLine();
+                builder.AppendFormat("Required Tags: {0}", string.Join(", ", RequiredTags.items));
+                builder.AppendLine();
+                builder.AppendFormat("Excluded Tags: {0}", string.Join(", ", ExcludedTags.items));
+                builder.AppendLine();
+                builder.Append("----------------------------------------------------------------------");
+                builder.AppendLine();
+
+                sortedUnits.AddRange(Units.AsEnumerable());
+                var sortedList = sortedUnits.OrderByDescending(unit => GetUnitCount(unit.Key)).ToList();
+                for (int i = 0; i < sortedList.Count; i++) {
+                    builder.AppendFormat("{0,6} | {1,2} - {2}", ((double)GetUnitCount(sortedList[i].Key) / (double)TotalUnits).ToString("p2", numberInfo), GetUnitCount(sortedList[i].Key), sortedList[i].Key);
+
+                    List<KeyValuePair<string, int>> sortedVariants = new();
+                    sortedVariants.AddRange(sortedList[i].Value.AsEnumerable());
+                    foreach (var variant in sortedVariants.OrderByDescending(unit => unit.Value)) {
+                        builder.AppendLine();
+                        builder.AppendFormat("\t{0,6} | {1,2} - {2}",((double)variant.Value / (double)TotalUnits).ToString("p2", numberInfo), variant.Value, variant.Key);
+                    }
+                    builder.AppendLine();
+                }
+                builder.Append("----------------------------------------------------------------------");
+                builder.AppendLine();
+                builder.AppendFormat("Selected: {0} - ({1}/{2}) | ({3}/{4})", 
+                    Selected.UnitDefID,
+                    ((double)GetUnitCount(Selected.FriendlyName) / (double)TotalUnits).ToString("p2", numberInfo),
+                    ((double)Units[Selected.FriendlyName][Selected.UnitDefID] / (double)TotalUnits).ToString("p2", numberInfo),
+                    GetUnitCount(Selected.FriendlyName),
+                    Units[Selected.FriendlyName][Selected.UnitDefID]);
+                builder.AppendLine();
+                builder.Append("----------------------------------------------------------------------");
+                builder.AppendLine();
+                return builder.ToString();
+            }
         }
 
-        private static void Postfix(ref List<UnitDef_MDD> __result) {
-            try {
-                RTS.modLog.Info?.Write($"Old Length: {__result.Count}");
-                foreach (UnitDef_MDD unitDef in __result.ToArray()) {
-                    int toAdd = numberToAdd(unitDef);
+        [HarmonyPatch(typeof(TagSetQueryExtensions), "GetMatchingUnitDefs")]
+        public static class TagSetQueryExtensions_GetMatchingUnitDefs {
+            private static Dictionary<string, int> numberToAddCache = new Dictionary<string, int>();
+            public  static int numberToAdd(UnitDef_MDD unitDef) {
+                if (numberToAddCache.ContainsKey(unitDef.UnitDefID)) {
+                    return numberToAddCache[unitDef.UnitDefID];
+                }
 
-                    if (toAdd > 0) {
-                        RTS.modLog.Info?.Write($"Possible unit: {unitDef.UnitDefID}. Adding {toAdd} to list.");
-                        for (int i = 0; i < toAdd; i++) {
-                            __result.Add(unitDef);
-                        }
+                Settings s = RTS.settings;
+                int toAdd = 0;
+
+                foreach (Tag_MDD tag in unitDef.TagSetEntry.Tags) {
+                    if (s.moreCommonTags.ContainsKey(tag.Name)) {
+                        toAdd += s.moreCommonTags[tag.Name];
                     }
                 }
-                RTS.modLog.Info?.Write($"New Length: {__result.Count}");
-            } catch (Exception e) {
-                RTS.modLog.Error?.Write(e);
+                numberToAddCache[unitDef.UnitDefID] = toAdd;
+                return toAdd;
+            }
+
+            private static void Postfix(ref List<UnitDef_MDD> __result, TagSet requiredTags, TagSet excludedTags, TagSet companyTags) {
+                try {
+                    TagBreakdown.Instance = new TagBreakdown(__result.Count, requiredTags, excludedTags, companyTags);
+                    foreach (UnitDef_MDD unitDef in __result.ToArray()) {
+                        int toAdd = numberToAdd(unitDef);
+                        TagBreakdown.Instance.AddUnit(unitDef);
+                        if (toAdd > 0) {
+                            for (int i = 0; i < toAdd; i++) {
+                                __result.Add(unitDef);
+                            }
+                        }
+                    }
+
+                } catch (Exception e) {
+                    RTS.modLog.Error?.Write(e);
+                }
+            }
+        }
+
+        [HarmonyPatch(typeof(UnitSpawnPointOverride), nameof(UnitSpawnPointOverride.SelectTaggedUnitDef))]
+        public static class TagSetQueryExtensions_SelectTaggedUnitDef {
+            private static void Postfix(ref UnitDef_MDD __result) {
+                try {
+                    if (TagBreakdown.Instance == null) {
+                        RTS.modLog.Info?.Write("Failed to find TagBreakdown");
+                        return;
+                    }
+                    TagBreakdown.Instance.Selected = __result;
+                    RTS.modLog.Info?.Write($"Generating new Spawn Table\n{TagBreakdown.Instance.CreateOutputTable()}");
+
+                } catch (Exception e) {
+                    RTS.modLog.Error?.Write(e);
+                }
             }
         }
     }
+    
 }

--- a/src/patches/TagSetQueryExtensions.cs
+++ b/src/patches/TagSetQueryExtensions.cs
@@ -69,7 +69,7 @@ namespace RarityTiedSpawner {
                 StringBuilder builder = new StringBuilder();
                 List<KeyValuePair<string, Dictionary<string, int>>> sortedUnits = new();
                 builder.AppendLine();
-                builder.Append("----------------------------------------------------------------------");
+                builder.Append("----------------------------------------------------------------------------------------------------");
                 builder.AppendLine();
                 builder.AppendFormat("Old Length: {0} | New Length: {1}", OldLength, TotalUnits);
                 builder.AppendLine();
@@ -77,7 +77,7 @@ namespace RarityTiedSpawner {
                 builder.AppendLine();
                 builder.AppendFormat("Excluded Tags: {0}", string.Join(", ", ExcludedTags.items));
                 builder.AppendLine();
-                builder.Append("----------------------------------------------------------------------");
+                builder.Append("----------------------------------------------------------------------------------------------------");
                 builder.AppendLine();
 
                 sortedUnits.AddRange(Units.AsEnumerable());
@@ -93,16 +93,17 @@ namespace RarityTiedSpawner {
                     }
                     builder.AppendLine();
                 }
-                builder.Append("----------------------------------------------------------------------");
+                builder.Append("----------------------------------------------------------------------------------------------------");
                 builder.AppendLine();
-                builder.AppendFormat("Selected: {0} - ({1}/{2}) | ({3}/{4})", 
+                builder.AppendFormat("Selected: {0} - {1} | ({2}/{3}) | ({4}/{5})",
+                    Selected.FriendlyName,
                     Selected.UnitDefID,
                     ((double)GetUnitCount(Selected.FriendlyName) / (double)TotalUnits).ToString("p2", numberInfo),
                     ((double)Units[Selected.FriendlyName][Selected.UnitDefID] / (double)TotalUnits).ToString("p2", numberInfo),
                     GetUnitCount(Selected.FriendlyName),
                     Units[Selected.FriendlyName][Selected.UnitDefID]);
                 builder.AppendLine();
-                builder.Append("----------------------------------------------------------------------");
+                builder.Append("----------------------------------------------------------------------------------------------------");
                 builder.AppendLine();
                 return builder.ToString();
             }

--- a/src/patches/TagSetQueryExtensions.cs
+++ b/src/patches/TagSetQueryExtensions.cs
@@ -268,24 +268,6 @@ namespace RarityTiedSpawner {
 
         [HarmonyPatch(typeof(TagSetQueryExtensions), "GetMatchingUnitDefs")]
         public static class TagSetQueryExtensions_GetMatchingUnitDefs {
-            private static Dictionary<string, int> numberToAddCache = new Dictionary<string, int>();
-            public static int numberTsoAdd(UnitDef_MDD unitDef) {
-                if (numberToAddCache.ContainsKey(unitDef.UnitDefID)) {
-                    return numberToAddCache[unitDef.UnitDefID];
-                }
-
-                Settings s = RTS.settings;
-                int toAdd = 0;
-
-                foreach (Tag_MDD tag in unitDef.TagSetEntry.Tags) {
-                    if (s.moreCommonTags.ContainsKey(tag.Name)) {
-                        toAdd += s.moreCommonTags[tag.Name];
-                    }
-                }
-                numberToAddCache[unitDef.UnitDefID] = toAdd;
-                return toAdd;
-            }
-
             private static void Postfix(ref List<UnitDef_MDD> __result, TagSet requiredTags, TagSet excludedTags, TagSet companyTags) {
                 try {
                     TagBreakdown.Instance = new TagBreakdown(__result.Count, requiredTags, excludedTags, companyTags);


### PR DESCRIPTION
This supplies support for new types of rarity tags that can be applied conditionally based on the Required and Excluded tags used to select units. These are constructed with the ``dynamicTag`` field and ``excludeTag`` in settings.

This is structured thusly:
```
{dynamicTag}_{X} // Add X instances of the mech regardless of required or exclude tags
{TargetTag}_{dynamicTag}_{x} // Add X instances of the mech if the target Tag is in the required tags list
{excludeTag}_{TargetTag}_{dynamicTag}_{x} // Add X instances of the mech if the target Tag is in the exclude tags list
```

For Example let ``dynamicTag`` = "unit_rarity" and ``excludeTag`` = "not"
```
"unit_rarity_2" //Adds 2 copies if the unit matches the requested tags
"ClanWolf_unit_rarity_2" //Adds 2 copies if the required tags includes ClanWolf
"not_unit_heavy_unit_rarity_3" //Adds 2 copies if the exclude tags include unit_heavy
```

